### PR TITLE
Output variables and path handling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Version on Github](https://img.shields.io/github/release/dillingham/stubs.svg?style=flat-square)](https://packagist.org/packages/dillingham/stubs)
 [![Total Downloads](https://img.shields.io/packagist/dt/dillingham/stubs.svg?style=flat-square)](https://packagist.org/packages/dillingham/stubs)
 
-A package to create files, folders & content with variables. 
+A package to create files, folders and content with variables. 
 
 ### Install
 
@@ -14,9 +14,9 @@ composer require dillingham/stubs
 
 ### Variables
 
-Variables are declared as an associative array
+Variables are declared as an associative array.
 
-The `key` is referenced between brackets {{key}}
+The `key` is referenced in the file paths and contents between brackets, as `{{key}}`.
 
 ```php
 [
@@ -26,38 +26,58 @@ The `key` is referenced between brackets {{key}}
 ]
 ```
 
-becomes: {{name}} {{plural}} {{lower}}
+becomes `{{name}}` `{{plural}}` `{{lower}}`.
 
 ### Usage
 
-Simply declare the  source and output and which variables to parse.
+Simply declare the source and output and which variables to parse.
 ```php
 use Stub\Stub;
 ```
+#### Copy the contents of one folder to another folder
+```php
+Stub::source('stubs')->output('output')->parse($variables);
+```
 
+#### Copy one file to a folder
 ```php
-Stub::source('/folder')->output('/folder')->parse($variables);
+Stub::source('stubs/file.php')->output('output')->parse($variables);
+```
+
+#### Copy one file to another file
+```php
+Stub::source('stubs/file.php')->output('output/newfile.php', true)->parse($variables);
+```
+
+#### Use variables in the output path
+```php
+Stub::source('stubs/file.php')->output('output/{{name}}')->parse($variables);
 ```
 ```php
-Stub::source('/folder/file.php')->output('/folder')->parse($variables);
+Stub::source('stubs/file.php')->output('output/{{name}}/newfile.php', true)->parse($variables);
 ```
+
+#### Process the contents of a folder and send the results to a callback
 ```php
-Stub::source('/folder')
-    ->output(function($path, $content){
+Stub::source('stubs')
+    ->output(function($path, $content) {
         // called for every parsed file
     })->parse($variables);
 ```
+You must store each file yourself in the callback.
+
+#### Process one file and send the results to a callback
 ```php
-Stub::source('/folder/file.php')
-    ->output(function($path, $content){
+Stub::source('stubs/file.php')
+    ->output(function($path, $content) {
         // called for the single file
     })->parse($variables);
 ```
+You must store the file yourself in the callback.
 
 ### Example [view](https://github.com/dillingham/stubs/tree/master/tests/stubs)
 
-
-Folder names
+#### Folder names
 
 ```
 views/{{plural}}/index.blade.php
@@ -66,7 +86,7 @@ views/{{plural}}/index.blade.php
 views/users/index.blade.php
 ```
 
-File names
+#### File names
 
 ```
 controllers/{{name}}Controller.php
@@ -75,7 +95,7 @@ controllers/{{name}}Controller.php
 controllers/UserController.php
 ```
 
-File content
+#### File content
 
 ```php
 class {{name}}Controller
@@ -93,7 +113,7 @@ class UserController
 }
 ```
 
-You can also append `.stub` to avoid IDE errors
+You can also append `.stub` to avoid IDE errors:
 
 ```
 controllers/{{name}}Controller.php.stub

--- a/src/Stub.php
+++ b/src/Stub.php
@@ -118,7 +118,7 @@ class Stub
             return $filepath;
         }
 
-        return rtrim($this->output, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filepath;
+        return rtrim($this->variables($this->output), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filepath;
     }
 
     protected function files()

--- a/src/Stub.php
+++ b/src/Stub.php
@@ -116,8 +116,14 @@ class Stub
             $path = $this->folder($path);
         }
 
+        $target_path = self::$path;
+
+        if (!$this->fileOutput && self::$method == 'parseFile') {
+            $target_path = dirname($target_path);
+        }
+
         $filepath_parts = explode(DIRECTORY_SEPARATOR, $path);
-        $folder_parts = explode(DIRECTORY_SEPARATOR, self::$path);
+        $folder_parts = explode(DIRECTORY_SEPARATOR, $target_path);
 
         $common = array_intersect_assoc($filepath_parts, $folder_parts);
 

--- a/tests/StubRelativeTest.php
+++ b/tests/StubRelativeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests;
+
+use Stub\Stub;
+
+class StubRelativeTest extends TestCase
+{
+    public function testRelativeDirectoryToDirectoryStubbing()
+    {
+        Stub::source('stubs')
+            ->output('output')
+            ->parse(['name' => 'User', 'lower' => 'user']);
+
+        $this->assertFileExists('output/User.php');
+        $this->assertFileExists('output/folder/UserFactory.php');
+        $this->assertFileExists('output/User-folder/Example.php');
+        $this->assertFileExists('output/folder/another-folder/UserController.php');
+
+        $this->assertEquals('User is present', file_get_contents('output/User.php'));
+    }
+
+    public function testRelativeFileToDirectoryStubbing()
+    {
+        Stub::source('stubs/{{name}}.php.stub')
+            ->output('output')
+            ->parse(['name' => 'User', 'lower' => 'user']);
+
+        $this->assertFileExists('output/User.php');
+
+        $this->assertEquals('User is present', file_get_contents('output/User.php'));
+    }
+
+    public function testRelativeFileToFileStubbing()
+    {
+        Stub::source('stubs/{{name}}.php.stub')
+            ->output('output/NewUser.php', true)
+            ->parse(['name' => 'User', 'lower' => 'user']);
+
+        $this->assertFileExists('output/NewUser.php');
+
+        $this->assertEquals('User is present', file_get_contents('output/NewUser.php'));
+    }
+
+    public function testRelativeVariablesInOutputDirectoryStubbing()
+    {
+        Stub::source('stubs/{{name}}.php.stub')
+            ->output('output/{{lower}}')
+            ->parse(['name' => 'User', 'lower' => 'user']);
+
+        $this->assertFileExists('output/user/User.php');
+
+        $this->assertEquals('User is present', file_get_contents('output/user/User.php'));
+    }
+
+    public function testRelativeVariablesInOutputFileStubbing()
+    {
+        Stub::source('stubs/{{name}}.php.stub')
+            ->output('output/{{lower}}/{{name}}Model.php', true)
+            ->parse(['name' => 'User', 'lower' => 'user']);
+
+        $this->assertFileExists('output/user/UserModel.php');
+
+        $this->assertEquals('User is present', file_get_contents('output/user/UserModel.php'));
+    }
+}

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -31,6 +31,17 @@ class StubTest extends TestCase
         $this->assertEquals('User is present', file_get_contents(__DIR__.'/output/User.php'));
     }
 
+    public function testVariablesInOutputStubbing()
+    {
+        Stub::source(__DIR__.'/stubs/{{name}}.php.stub')
+            ->output(__DIR__.'/output/{{lower}}')
+            ->parse(['name' => 'User', 'lower' => 'user']);
+
+        $this->assertFileExists(__DIR__.'/output/user/User.php');
+
+        $this->assertEquals('User is present', file_get_contents(__DIR__.'/output/user/User.php'));
+    }
+
     public function testDirectoryToCallbackStubbing()
     {
         Stub::source(__DIR__.'/stubs/')

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests;
 
 use Stub\Stub;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,12 @@ use PHPUnit\Framework\TestCase as BaseCase;
 
 class TestCase extends BaseCase
 {
-    public function tearDown() :void
+    public function setUp(): void
+    {
+        chdir(__DIR__);
+    }
+
+    public function tearDown(): void
     {
         $dir = __DIR__.'/output';
 


### PR DESCRIPTION
Hi @dillingham 

I know this is a package you've only just started on, but it is exactly what I was looking for and so I have gone in headfirst! 😄  I added a few new features and patched some issues with the way the common file paths were being handled using `array_intersect()`.

1. Allow variables in the output path (fixes #1).
1. Allow the output path to be either a directory or a single filepath (with `$isFile` argument).
1. Ensured consistent behaviour using absolute or relative paths.
1. Used `array_intersect_assoc()` instead of `array_intersect()` in `getBasePath()` to ensure common path segments *from the front of the paths only* are stripped, not from anywhere contained in either path (fixes #2).
  This highlighted some other issues with the path handling which were resolved:
    * Don't `ltrim()` the `DIRECTORY_SEPARATOR` in `resolvePath()` as it will make absolute paths invalid.
    * Don't add trailing `DIRECTORY_SEPARATOR` in `getBasePath()` if the filepath is empty.
    * Don't `mkdir()` the folder if it is empty.
    * Don't `basename()` the path in `parseFile()`.
5. Added tests and doc for new functionality/ fixes.

Thanks for your package and I hope this is useful.