### PR TITLE
Add listener after files created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
 /vendor
+/tests/project

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ use Stub\Stub;
 ```php
 (new Stub)
     ->source('stubs/stub-2')
-    ->output(function($path, $content) {
+    ->output(function(string $path, string $content) {
         // called for each rendered file, INSTEAD of creating it
     })->render($variables);
 ```

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ becomes `{{name}}` `{{plural}}` `{{lower}}`.
 
 ### Variable Placement
 
-Variables can be in filepaths, filenames & in the content
+Variables can be in file paths, file names and in the content:
 
 ```
 /views/{{name}}/index.blade.php
 ```
 ```
-<buton>Create {{name}}</button>
+<button>Create {{name}}</button>
 ```
 
-For a basic example, [click here](https://github.com/dillingham/stubs/tree/master/tests/stubs)
+For a basic example, [click here](https://github.com/dillingham/stubs/tree/master/tests/stubs).
 
 ### Render stubs
 
@@ -55,7 +55,7 @@ Note: optionally append `.stub` to filenames to avoid IDE errors.
 ```php
 use Stub\Stub;
 ```
-#### Process a folder & output files to another folder:
+#### Process a folder and output files to another folder:
 ```php
 (new Stub)
     ->source('stubs/stub-1')
@@ -68,10 +68,23 @@ use Stub\Stub;
 (new Stub)
     ->source('stubs/stub-2')
     ->output(function($path, $content) {
-        // called for each renderd file
+        // called for each rendered file, INSTEAD of creating it
     })->render($variables);
 ```
-You must handle/store file(s) yourself in the callback.
+**You must handle/store file(s) yourself in the callback.** This may be used to modify the file's path or contents further before you store it.
+
+#### Process a folder and listen to all created files with a callback:
+```php
+(new Stub)
+    ->source('stubs/stub-3')
+    ->output('project-name')
+    ->listen(function(string $path, string $content, bool $success) {
+        // called for each rendered file, AFTER it is created
+    })->render($variables);
+```
+Unlike the `output()` callback above, the `listen()` callback is called *after* each file has already been created. This may be used to log or output the results of the process.
+
+The `render()` and `create()` methods return the number of files which were created by the process, which you can also log or output.
 
 ### Create stubs
 
@@ -109,13 +122,13 @@ You can pass variables to `stubs` like so:
 stub render ./source ./output key:value key:"value with spaces"
 ```
 
-For many or more complex variable sets, pass a json file path:
+For many or more complex variable sets, pass a JSON file path:
 
 ```bash
 stub render ./source ./output values.json
 ```
 
-Example of the json file content:
+Example of the JSON file content:
 
 ```json
 {

--- a/src/Console/Create.php
+++ b/src/Console/Create.php
@@ -38,8 +38,26 @@ class Create extends Command
             }
         }
 
-        (new Stub)->source($source)->output($output)->create($render);
+        $stubs = (new Stub)->source($source)->output($output);
 
-        $o->writeLn('<info>Stub created!</info>');
+        if ($o->isVerbose()) {
+            $stubs->listen(function ($path, $content, $success) use ($o) {
+                if ($success) {
+                    $o->writeLn('<info>Created</info> <comment>'.$path.'</comment>');
+                }
+                else {
+                    $o->writeLn('<error>Unable to create</error> <comment>'.$path.'</comment>');
+                }
+            });
+        }
+
+        $count = $stubs->create($render);
+
+        if ($count) {
+            $o->writeLn('<info>Stub created!</info> <comment>'.$count.'</comment> <info>file(s) created.</info>');
+        }
+        else {
+            $o->writeLn('<error>Unable to create stub! 0 files created.</error>');
+        }
     }
 }

--- a/src/Console/Render.php
+++ b/src/Console/Render.php
@@ -38,8 +38,26 @@ class Render extends Command
             }
         }
 
-        (new Stub)->source($source)->output($output)->render($render);
+        $stubs = (new Stub)->source($source)->output($output);
 
-        $o->writeLn('<info>Stub rendered!</info>');
+        if ($o->isVerbose()) {
+            $stubs->listen(function ($path, $content, $success) use ($o) {
+                if ($success) {
+                    $o->writeLn('<info>Rendered</info> <comment>'.$path.'</comment>');
+                }
+                else {
+                    $o->writeLn('<error>Unable to render</error> <comment>'.$path.'</comment>');
+                }
+            });
+        }
+
+        $count = $stubs->render($render);
+
+        if ($count) {
+            $o->writeLn('<info>Stub rendered!</info> <comment>'.$count.'</comment> <info>file(s) rendered.</info>');
+        }
+        else {
+            $o->writeLn('<error>Unable to render stub! 0 files rendered.</error>');
+        }
     }
 }

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -8,7 +8,7 @@ class StubTest extends TestCase
 {
     public function testDirectoryToDirectoryStubbingStub1()
     {
-        (new Stub)
+        $count = (new Stub)
             ->source(__DIR__.'/stubs/stub-1')
             ->output(__DIR__.'/project')
             ->render(['name' => 'User', 'lower_plural' => 'users']);
@@ -23,11 +23,13 @@ class StubTest extends TestCase
             'class UserObserver {}',
             file_get_contents(__DIR__.'/project/Observers/UserObserver.php')
         );
+
+        $this->assertEquals(4, $count);
     }
 
     public function testDirectoryToDirectoryStubbingStub2()
     {
-        (new Stub)
+        $count = (new Stub)
             ->source(__DIR__.'/stubs/stub-2')
             ->output(__DIR__.'/project')
             ->render(['name' => 'User', 'lower_plural' => 'users']);
@@ -37,6 +39,8 @@ class StubTest extends TestCase
             '<button>Create User</button>',
             file_get_contents(__DIR__.'/project/views/users/index.blade.php')
         );
+
+        $this->assertEquals(1, $count);
     }
 
     public function testDirectoryToCallbackStubbing()
@@ -87,5 +91,19 @@ class StubTest extends TestCase
             '{{name}}Controller',
             file_get_contents(__DIR__.'/project/Controllers/{{name}}Controller.php.stub')
         );
+    }
+
+    public function testListenerCallback()
+    {
+        (new Stub)
+            ->source(__DIR__.'/stubs/stub-2')
+            ->output(__DIR__.'/project')
+            ->listen(function ($path, $content, $success) {
+                $this->assertEquals(__DIR__.'/project/views/users/index.blade.php', $path);
+                $this->assertFileExists($path);
+                $this->assertEquals('<button>Create User</button>', $content);
+                $this->assertTrue($success);
+            })
+            ->render(['name' => 'User', 'lower_plural' => 'users']);
     }
 }


### PR DESCRIPTION
Hi @dillingham 

I have added a `listen()` method which takes a callback for each file after it is created, so you can return the list of file paths that were created. I've also made the `render()` and `create()` methods return the number of files that were successfully created. I've added these into the tests and the commands, so you can see how they could be used.

Thanks again for this package!