### PR TITLE
Add filter callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,20 @@ Note: optionally append `.stub` to filenames to avoid IDE errors.
         // Called for each parsed file, instead of storing it
         // Useful for further modifications before you store it
         // or posting to an API like stubbing a github repository
-        
+
+    })->render($variables);
+```
+
+#### Inspect & filter parsed files & content before outputing:
+
+```php
+(new Stub)
+    ->source('stubs/stub-3')
+    ->output('project-name')
+    ->filter(function($path, $content) {
+        // called for each rendered file, BEFORE it is created
+        // return false will prevent the output of that path
+        // returning true or nothing will proceeed normally
     })->render($variables);
 ```
 
@@ -80,7 +93,7 @@ Note: optionally append `.stub` to filenames to avoid IDE errors.
         // Called for each file after the file it is parsed & stored
         // This may be used to log or output the results of the process
         // $success is either true / false depending on the storing result
-        
+
     })->render($variables);
 ```
 

--- a/src/Stub.php
+++ b/src/Stub.php
@@ -14,6 +14,7 @@ class Stub
     public $openTag = '{{';
     public $closeTag = '}}';
     public $appendFilename;
+    public $filter;
     public $listener;
 
     public function source($path)
@@ -64,11 +65,22 @@ class Stub
         return $this;
     }
 
+    public function filter(callable $filter)
+    {
+        $this->filter = $filter;
+
+        return $this;
+    }
+
     protected function handleOutput($path)
     {
         $content = $this->resolveContent($path);
 
         $path = $this->resolvePath($path);
+
+        if ($this->isFiltered($path, $content)) {
+            return false;
+        }
 
         if (is_callable(($this->output))) {
             return ($this->output)($path, $content);
@@ -140,6 +152,12 @@ class Stub
         array_multisort($keys, SORT_DESC, $array);
 
         return $array;
+    }
+
+    protected function isFiltered($path, $content)
+    {
+        return is_callable(($this->filter))
+            && ($this->filter)($path, $content) === false;
     }
 
     protected function files()

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -137,4 +137,42 @@ class StubTest extends TestCase
                 $this->assertTrue($success);
             })->render(['name' => 'User', 'lower_plural' => 'users']);
     }
+
+    public function testFilterFalseCallback()
+    {
+        (new Stub)
+            ->source(__DIR__.'/stubs/stub-2')
+            ->output(__DIR__.'/project')
+            ->filter(function ($path, $content) {
+                $this->assertContains('views/users', $path);
+
+                return false;
+            })->render(['lower_plural' => 'users']);
+
+        $this->assertDirectoryNotExists(__DIR__.'/project/views/users');
+    }
+
+    public function testFilterTrueCallback()
+    {
+        (new Stub)
+            ->source(__DIR__.'/stubs/stub-2')
+            ->output(__DIR__.'/project')
+            ->filter(function ($path, $content) {
+                return true;
+            })->render(['lower_plural' => 'users']);
+
+        $this->assertDirectoryExists(__DIR__.'/project/views/users');
+    }
+
+    public function testFilterBlankCallback()
+    {
+        (new Stub)
+            ->source(__DIR__.'/stubs/stub-2')
+            ->output(__DIR__.'/project')
+            ->filter(function ($path, $content) {
+                //
+            })->render(['lower_plural' => 'users']);
+
+        $this->assertDirectoryExists(__DIR__.'/project/views/users');
+    }
 }


### PR DESCRIPTION
```php
(new Stub)
    ->source('stubs/stub-3')
    ->output('project-name')
    ->filter(function($path, $content) {
        // called for each parsed file, before it is created
        // returning false prevents outputting that file
        // returning true / nothing proceeds normally
    })->render($variables);
```



Not entirely sure what the use case is haha
I would assume a stub source would only have files you want 
So not going to merge until I can think of a solid reason
But felt symmetrical with output()  & listen()

Maybe filter vendor / node_module paths 🤔 
Although that seems like a `ignore`  / pre parse feature