### PR TITLE
Source settings stub.json

### DIFF
--- a/src/Console/Render.php
+++ b/src/Console/Render.php
@@ -4,6 +4,7 @@ namespace Stub\Console;
 
 use Stub\Stub;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,9 +30,20 @@ class Render extends Command
 
         $render = [];
 
+
+        if (count($variables) == 0) {
+            $settings = $stub->settings($source);
+            foreach ($settings as $question => $var) {
+                $question = new Question($question);
+                $render[$var] = $helper->ask($i, $o, $question);
+            }
+        }
+
         if (count($variables) == 1 && file_exists($variables[0])) {
             $render = json_decode(file_get_contents($variables[0]), true);
-        } else {
+        }
+
+        if (empty($render)) {
             foreach ($variables as $index => $keyValue) {
                 $keyValue = explode(':', $keyValue);
                 $render[$keyValue[0]] = $keyValue[1];

--- a/src/Console/Render.php
+++ b/src/Console/Render.php
@@ -53,6 +53,12 @@ class Render extends Command
 
         $stubs = (new Stub)->source($source)->output($output);
 
+        if (isset($sourceConfig)) {
+            $stubs->filter(function ($path, $content) {
+                return $path != 'stub.json';
+            });
+        }
+
         if ($o->isVerbose()) {
             $stubs->listen(function ($path, $content, $success) use ($o) {
                 if ($success) {

--- a/src/Console/Render.php
+++ b/src/Console/Render.php
@@ -32,9 +32,10 @@ class Render extends Command
 
 
         if (count($variables) == 0) {
-            $settings = $stub->settings($source);
+            $helper = $this->getHelper('question');
+            $settings = (new Stub)->settings($source);
             foreach ($settings as $question => $var) {
-                $question = new Question($question);
+                $question = new Question("$question: ");
                 $render[$var] = $helper->ask($i, $o, $question);
             }
         }

--- a/src/Console/Render.php
+++ b/src/Console/Render.php
@@ -30,13 +30,12 @@ class Render extends Command
 
         $render = [];
 
-
         if (count($variables) == 0) {
             $helper = $this->getHelper('question');
-            $settings = (new Stub)->settings($source);
-            foreach ($settings as $question => $var) {
+            $sourceConfig = (new Stub)->settings($source);
+            foreach ($sourceConfig as $question => $variable) {
                 $question = new Question("$question: ");
-                $render[$var] = $helper->ask($i, $o, $question);
+                $render[$variable] = $helper->ask($i, $o, $question);
             }
         }
 
@@ -63,8 +62,7 @@ class Render extends Command
             $stubs->listen(function ($path, $content, $success) use ($o) {
                 if ($success) {
                     $o->writeLn('<info>Rendered</info> <comment>'.$path.'</comment>');
-                }
-                else {
+                } else {
                     $o->writeLn('<error>Unable to render</error> <comment>'.$path.'</comment>');
                 }
             });
@@ -74,8 +72,7 @@ class Render extends Command
 
         if ($count) {
             $o->writeLn('<info>Stub rendered!</info> <comment>'.$count.'</comment> <info>file(s) rendered.</info>');
-        }
-        else {
+        } else {
             $o->writeLn('<error>Unable to render stub! 0 files rendered.</error>');
         }
     }

--- a/src/Stub.php
+++ b/src/Stub.php
@@ -168,4 +168,15 @@ class Stub
 
         return $this;
     }
+
+    public function settings($path)
+    {
+        $path = "$path/stub.json";
+
+        if (file_exists($path)) {
+            return json_decode(file_get_contents($path), true);
+        }
+
+        return [];
+    }
 }

--- a/src/Stub.php
+++ b/src/Stub.php
@@ -2,6 +2,7 @@
 
 namespace Stub;
 
+use InvalidArgumentException;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 
@@ -177,6 +178,6 @@ class Stub
             return json_decode(file_get_contents($path), true);
         }
 
-        return [];
+        throw new InvalidArgumentException("$path does not contain a stub.json");
     }
 }

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Stub\Stub;
+use InvalidArgumentException;
 
 class StubTest extends TestCase
 {
@@ -144,5 +145,12 @@ class StubTest extends TestCase
         $this->assertEquals($settings['User\'s name'], 'name');
         $this->assertEquals($settings['User\'s email'], 'email');
         $this->assertEquals($settings['User\'s title'], 'title');
+    }
+
+    public function testExceptionWhenSettingsMissing()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Stub)->settings('stubs/stub-2');
     }
 }

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -137,4 +137,12 @@ class StubTest extends TestCase
                 $this->assertTrue($success);
             })->render(['name' => 'User', 'lower_plural' => 'users']);
     }
+
+    public function testGetSourceStubSettings()
+    {
+        $settings = (new Stub)->settings('stubs/stub-3');
+        $this->assertEquals($settings['User\'s name'], 'name');
+        $this->assertEquals($settings['User\'s email'], 'email');
+        $this->assertEquals($settings['User\'s title'], 'title');
+    }
 }

--- a/tests/stubs/stub-3/stub.json
+++ b/tests/stubs/stub-3/stub.json
@@ -1,0 +1,5 @@
+{
+    "User's name": "name",
+    "User's email": "email",
+    "User's title": "title"
+}

--- a/tests/stubs/stub-3/user.vcf
+++ b/tests/stubs/stub-3/user.vcf
@@ -1,0 +1,6 @@
+BEGIN:VCARD
+VERSION:2.1
+FN:{{name}}
+TITLE:{{title}}
+EMAIL;PREF;INTERNET:{{email}}
+END:VCARD


### PR DESCRIPTION
Allows users to use stub.json from stub source folder as the variables when you don't add variables to `render` command in the console. Basically lets you setup instructions for using the stub.

```
php artisan stub:render source outcome
```
```json
{
    "What is the resource name": "resource"
}
```
Looks into the directory and loads the stub.json into an interactive QA:
```
What is the resource name:
```

Then renders the stub with user's value as `{{resource}}`

This can be useful for distributing stubs as well

```
composer require dillingham/stubs:dev-source-stub.json
```