### PR TITLE
Variable Sets redux --> Formatters

### DIFF
--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -29,7 +29,7 @@ abstract class Formatter
      * @param  string[]  $variables
      * @return string[]
      */
-    public static function make(array $variables)
+    final public static function make(array $variables)
     {
         return (new static($variables))->all();
     }
@@ -39,7 +39,7 @@ abstract class Formatter
      * @param  string $attribute
      * @return string
      */
-    public function __get(string $attribute)
+    final public function __get(string $attribute)
     {
         return $this->get($attribute);
     }
@@ -50,7 +50,7 @@ abstract class Formatter
      * @param  string $value
      * @return $this
      */
-    public function __set(string $attribute, string $value)
+    final public function __set(string $attribute, string $value)
     {
         return $this->set($attribute, $value);
     }
@@ -61,7 +61,7 @@ abstract class Formatter
      * @param array $attributes
      * @return string
      */
-    public function __call(string $name, array $attributes)
+    final public function __call(string $name, array $attributes)
     {
         if (!count($attributes) && $this->has($name)) {
             return $this->get($name);
@@ -99,6 +99,15 @@ abstract class Formatter
     }
 
     /**
+     * Return the original variables only.
+     * @return string[]
+     */
+    final public function original()
+    {
+        return $this->variables;
+    }
+
+    /**
      * Validate any values passed to the variable set.
      *
      * Override this method in your own class and throw an
@@ -117,7 +126,7 @@ abstract class Formatter
      * Invoke the formatter and compute the variables.
      * @return string[]
      */
-    public function __invoke()
+    final public function __invoke()
     {
         return $this->all();
     }
@@ -128,7 +137,7 @@ abstract class Formatter
      * @param  string $variable
      * @return bool
      */
-    public function has($variable): bool
+    final public function has($variable): bool
     {
         return array_key_exists($variable, $this->variables);
     }
@@ -139,7 +148,7 @@ abstract class Formatter
      * @param string $variable
      * @return string
      */
-    public function get(string $variable)
+    final public function get(string $variable)
     {
         if ($this->has($variable)) {
             return $this->variables[$variable];
@@ -157,7 +166,7 @@ abstract class Formatter
      * @param string $value
      * @return $this
      */
-    public function set(string $variable, string $value)
+    final public function set(string $variable, string $value)
     {
         $this->variables[$variable] = $value;
 
@@ -170,7 +179,7 @@ abstract class Formatter
      * @param string $variable
      * @return $this
      */
-    public function unset(string $variable)
+    final public function unset(string $variable)
     {
         unset($this->variables[$variable]);
 
@@ -183,7 +192,7 @@ abstract class Formatter
      * @param string[] $variables
      * @return $this
      */
-    public function merge(array $variables)
+    final public function merge(array $variables)
     {
         foreach ($variables as $variable => $value) {
             $this->variables[$variable] = $value;
@@ -198,7 +207,7 @@ abstract class Formatter
      * @param string[] $variables
      * @return $this
      */
-    public function replace(array $variables)
+    final public function replace(array $variables)
     {
         $this->variables = [];
 

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Stub;
+
+abstract class Formatter
+{
+    /**
+     * The base variables.
+     * @var string[]
+     */
+    public $variables;
+
+    /**
+     * Construct the formatter.
+     * @param string[] $variables
+     */
+    public function __construct(array $variables)
+    {
+        $this->variables = $variables;
+    }
+
+    /**
+     * Get a variable value.
+     * @param  string $attribute
+     * @return string
+     */
+    public function __get(string $attribute)
+    {
+        if (isset($this->variables[$attribute])) {
+            return $this->variables[$attribute];
+        }
+    }
+
+    /**
+     * Compute the variables.
+     * @return string[]
+     */
+    public function compute()
+    {
+        $this->validate();
+
+        $computed = $this->variables;
+
+        $methods = array_diff(
+            get_class_methods(get_called_class()),
+            get_class_methods(get_class())
+        );
+
+        print_r($methods);die;
+
+        foreach ($methods as $method) {
+            $computed[$method] = $this->$method();
+        }
+
+        return $computed;
+    }
+
+    /**
+     * Validate any values passed to the variable set.
+     *
+     * Override this method in your own class and throw an
+     * InvalidArgumentException if any expected variable is missing
+     * or is not in the required format.
+     *
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    protected function validate()
+    {
+        //
+    }
+
+    /**
+     * Invoke the formatter and compute the variables.
+     * @return string[]
+     */
+    public function __invoke()
+    {
+        return $this->compute();
+    }
+}

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -191,4 +191,17 @@ abstract class Formatter
 
         return $this;
     }
+
+    /**
+     * Replace existing variables with new variables.
+     *
+     * @param string[] $variables
+     * @return $this
+     */
+    public function replace(array $variables)
+    {
+        $this->variables = [];
+
+        return $this->merge($variables);
+    }
 }

--- a/src/Stub.php
+++ b/src/Stub.php
@@ -26,14 +26,14 @@ class Stub
     /**
      * The successfully stubbed file(s).
      *
-     * @var array
+     * @var string[]
      */
     public $rendered = [];
 
     /**
      * The data to search / replace.
      *
-     * @var array
+     * @var string[]
      */
     public $variables = [];
 
@@ -108,7 +108,7 @@ class Stub
     /**
      * Compile the source to output.
      *
-     * @param array $variables
+     * @param string[] $variables
      * @return $this
      */
     public function render(array $variables)
@@ -127,10 +127,10 @@ class Stub
     /**
      * Convert files into a stub
      *
-     * @param array $variables
+     * @param string[] $variables
      * @return $this
      */
-    public function create($variables)
+    public function create(array $variables)
     {
         $variables = $this->orderByKeyLength($variables);
 

--- a/src/Stub.php
+++ b/src/Stub.php
@@ -108,12 +108,12 @@ class Stub
     /**
      * Compile the source to output.
      *
-     * @param string[] $variables
+     * @param string[]|\Stub\Formatter $variables
      * @return $this
      */
-    public function render(array $variables)
+    public function render($variables)
     {
-        $this->variables = $variables;
+        $this->variables = $this->getVariableValues($variables);
 
         foreach ($this->files() as $file) {
             $this->handleOutput($file);
@@ -127,12 +127,12 @@ class Stub
     /**
      * Convert files into a stub
      *
-     * @param string[] $variables
+     * @param string[]|\Stub\Formatter $variables
      * @return $this
      */
-    public function create(array $variables)
+    public function create($variables)
     {
-        $variables = $this->orderByKeyLength($variables);
+        $variables = $this->orderByKeyLength($this->getVariableValues($variables));
 
         foreach ($variables as $key => $value) {
             unset($variables[$key]);
@@ -421,5 +421,23 @@ class Stub
         }
 
         throw new InvalidArgumentException("$path does not contain a stub.json");
+    }
+
+    /**
+     * Get values from variables or formatter.
+     *
+     * @param string[]|\Stub\Formatter $variables
+     * @return string[]
+     */
+    protected function getVariableValues($variables)
+    {
+        if ($variables instanceof Formatter) {
+            return $variables->all();
+        }
+        elseif (is_array($variables)) {
+            return $variables;
+        }
+
+        throw new InvalidArgumentException('Variables must be an array or instance of \Stub\Formatter');
     }
 }

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -66,6 +66,15 @@ class FormatterTest extends TestCase
         ], $variables);
     }
 
+    public function testFormatterOriginal()
+    {
+        $variables = (new Formatters\Example1(['name' => 'User']))->original();
+
+        $this->assertEquals([
+            'name' => 'User',
+        ], $variables);
+    }
+
     public function testFormatterAdditionalVariables()
     {
         $variables = (new Formatters\Example1(['name' => 'User', 'additional' => 'extra']))->all();

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -82,10 +82,12 @@ class FormatterTest extends TestCase
         $variables = (new Formatters\WithHelpers(['name' => 'User']))->all();
 
         $this->assertNotContains('helper', $variables);
-        $this->assertNotContains('helper_argument', $variables);
+        $this->assertNotContains('helper_with_argument', $variables);
 
         $this->assertEquals([
-            'name'         => 'User',
+            'name'                      => 'User',
+            'test_helper'               => '__HELPER__',
+            'test_helper_with_argument' => '__HELPER:ARGUMENT__',
         ], $variables);
     }
 

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests;
+
+use InvalidArgumentException;
+
+use Stub\Stub;
+use Tests\Formatters;
+
+class FormatterTest extends TestCase
+{
+    public function testNovaToolFormatter()
+    {
+        $package = 'test-vendor/test-package';
+
+        $variables = (new Formatters\NovaTool(['package' => $package]))->compute();
+
+        $this->assertEquals([
+            'package'          => 'test-vendor/test-package',
+            'component'        => 'test-package',
+            'title'            => 'Test Package',
+            'class'            => 'TestPackage',
+            'namespace'        => 'TestVendor\\TestPackage',
+            'name'             => 'test-package',
+            'vendor'           => 'test-vendor',
+            'escapedNamespace' => 'TestVendor\\\\TestPackage',
+        ], $variables);
+    }
+
+    public function testNovaToolFormatterValidateIncorrect()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The `package` variable expects a vendor and name in \'Composer\' format');
+
+        $package = 'not-a-package';
+
+        $variables = (new Formatters\NovaTool(['package' => $package]))->compute();
+    }
+
+    public function testNovaToolFormatterValidateMissing()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The `package` variable expects a vendor and name in \'Composer\' format');
+
+        $variables = (new Formatters\NovaTool([]))->compute();
+    }
+
+    public function testFormatterNoAdditional()
+    {
+        $variables = (new Formatters\Example1(['name' => 'User']))->compute();
+
+        $this->assertEquals([
+            'name'         => 'User',
+            'lower_plural' => 'users',
+        ], $variables);
+    }
+
+    public function testFormatterAdditionalArray()
+    {
+        $variables = (new Formatters\Example1(['name' => 'User', 'additional' => 'extra']))->compute();
+
+        $this->assertEquals([
+            'additional'   => 'extra',
+            'name'         => 'User',
+            'lower_plural' => 'users',
+        ], $variables);
+    }
+
+    public function testFormatterHelperMethods()
+    {
+        $variables = (new Formatters\WithHelpers(['name' => 'User']))->compute();
+
+        $this->assertEquals([
+            'name'         => 'User',
+            'lower_plural' => 'users',
+        ], $variables);
+    }
+
+    // public function testFormatterAdditionalFormatter()
+    // {
+    //     $postVariables = (new Formatters\Example2(['name' => 'Post']))->compute();
+    //     $variables = (new Formatters\Example1('User', $postVariables))->compute();
+    //
+    //     $this->assertEquals([
+    //         'name'              => 'User',
+    //         'lower_plural'      => 'users',
+    //         'post_name'         => 'Post',
+    //         'post_lower_plural' => 'posts',
+    //     ], $variables);
+    // }
+
+    public function testFormatterStubbing()
+    {
+        $variables = (new Formatters\Example1(['name' => 'Blog Post']))->compute();
+
+        $stub = (new Stub)
+            ->source(__DIR__.'/stubs/stub-2')
+            ->output(__DIR__.'/project')
+            ->render($variables);
+
+        $count = count($stub->rendered);
+
+        $this->assertFileExists(__DIR__.'/project/views/blog-posts/index.blade.php');
+        $this->assertEquals(
+            '<button>Create Blog Post</button>',
+            file_get_contents(__DIR__.'/project/views/blog-posts/index.blade.php')
+        );
+
+        $this->assertEquals(2, $count);
+    }
+}

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -89,7 +89,7 @@ class FormatterTest extends TestCase
         ], $variables);
     }
 
-    public function testFormatterStubbing()
+    public function testFormatterStubbingWithArray()
     {
         $variables = (new Formatters\Example1(['name' => 'Blog Post']))->all();
 
@@ -97,6 +97,26 @@ class FormatterTest extends TestCase
             ->source(__DIR__.'/stubs/stub-2')
             ->output(__DIR__.'/project')
             ->render($variables);
+
+        $count = count($stub->rendered);
+
+        $this->assertFileExists(__DIR__.'/project/views/blog-posts/index.blade.php');
+        $this->assertEquals(
+            '<button>Create Blog Post</button>',
+            file_get_contents(__DIR__.'/project/views/blog-posts/index.blade.php')
+        );
+
+        $this->assertEquals(2, $count);
+    }
+
+    public function testFormatterStubbingWithFormatterObject()
+    {
+        $formatter = new Formatters\Example1(['name' => 'Blog Post']);
+
+        $stub = (new Stub)
+            ->source(__DIR__.'/stubs/stub-2')
+            ->output(__DIR__.'/project')
+            ->render($formatter);
 
         $count = count($stub->rendered);
 

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -46,7 +46,17 @@ class FormatterTest extends TestCase
         $variables = (new Formatters\NovaTool([]))->all();
     }
 
-    public function testFormatterNoAdditional()
+    public function testFormatterInvoke()
+    {
+        $variables = (new Formatters\Example1(['name' => 'User']));
+
+        $this->assertEquals([
+            'name'         => 'User',
+            'lower_plural' => 'users',
+        ], $variables());
+    }
+
+    public function testFormatterBasic()
     {
         $variables = (new Formatters\Example1(['name' => 'User']))->all();
 
@@ -56,7 +66,7 @@ class FormatterTest extends TestCase
         ], $variables);
     }
 
-    public function testFormatterAdditionalArray()
+    public function testFormatterAdditionalVariables()
     {
         $variables = (new Formatters\Example1(['name' => 'User', 'additional' => 'extra']))->all();
 

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use ErrorException;
 use InvalidArgumentException;
 
 use Stub\Stub;
@@ -13,7 +14,7 @@ class FormatterTest extends TestCase
     {
         $package = 'test-vendor/test-package';
 
-        $variables = (new Formatters\NovaTool(['package' => $package]))->compute();
+        $variables = (new Formatters\NovaTool(['package' => $package]))->all();
 
         $this->assertEquals([
             'package'          => 'test-vendor/test-package',
@@ -34,20 +35,20 @@ class FormatterTest extends TestCase
 
         $package = 'not-a-package';
 
-        $variables = (new Formatters\NovaTool(['package' => $package]))->compute();
+        $variables = (new Formatters\NovaTool(['package' => $package]))->all();
     }
 
     public function testNovaToolFormatterValidateMissing()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The `package` variable expects a vendor and name in \'Composer\' format');
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Undefined variable: Tests\Formatters\NovaTool::$package');
 
-        $variables = (new Formatters\NovaTool([]))->compute();
+        $variables = (new Formatters\NovaTool([]))->all();
     }
 
     public function testFormatterNoAdditional()
     {
-        $variables = (new Formatters\Example1(['name' => 'User']))->compute();
+        $variables = (new Formatters\Example1(['name' => 'User']))->all();
 
         $this->assertEquals([
             'name'         => 'User',
@@ -57,7 +58,7 @@ class FormatterTest extends TestCase
 
     public function testFormatterAdditionalArray()
     {
-        $variables = (new Formatters\Example1(['name' => 'User', 'additional' => 'extra']))->compute();
+        $variables = (new Formatters\Example1(['name' => 'User', 'additional' => 'extra']))->all();
 
         $this->assertEquals([
             'additional'   => 'extra',
@@ -66,9 +67,9 @@ class FormatterTest extends TestCase
         ], $variables);
     }
 
-    public function testFormatterHelperMethods()
+    public function testFormatterStaticMake()
     {
-        $variables = (new Formatters\WithHelpers(['name' => 'User']))->compute();
+        $variables = Formatters\Example1::make(['name' => 'User']);
 
         $this->assertEquals([
             'name'         => 'User',
@@ -76,22 +77,21 @@ class FormatterTest extends TestCase
         ], $variables);
     }
 
-    // public function testFormatterAdditionalFormatter()
-    // {
-    //     $postVariables = (new Formatters\Example2(['name' => 'Post']))->compute();
-    //     $variables = (new Formatters\Example1('User', $postVariables))->compute();
-    //
-    //     $this->assertEquals([
-    //         'name'              => 'User',
-    //         'lower_plural'      => 'users',
-    //         'post_name'         => 'Post',
-    //         'post_lower_plural' => 'posts',
-    //     ], $variables);
-    // }
+    public function testFormatterHelperMethods()
+    {
+        $variables = (new Formatters\WithHelpers(['name' => 'User']))->all();
+
+        $this->assertNotContains('helper', $variables);
+        $this->assertNotContains('helper_argument', $variables);
+
+        $this->assertEquals([
+            'name'         => 'User',
+        ], $variables);
+    }
 
     public function testFormatterStubbing()
     {
-        $variables = (new Formatters\Example1(['name' => 'Blog Post']))->compute();
+        $variables = (new Formatters\Example1(['name' => 'Blog Post']))->all();
 
         $stub = (new Stub)
             ->source(__DIR__.'/stubs/stub-2')

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -130,4 +130,103 @@ class FormatterTest extends TestCase
 
         $this->assertEquals(2, $count);
     }
+
+    public function testFormatterVariableGet()
+    {
+        $formatter = new Formatters\Example2(['name' => 'Users']);
+
+        // Will return unmodified variable
+        $this->assertEquals('Users', $formatter->get('name'), 'Failed asserting that `->get(\'name\')` returns expected value.');
+        $this->assertEquals('Users', $formatter->name, 'Failed asserting that `->name` returns expected value.');
+
+        // Will return modified variable
+        $this->assertEquals('Users', $formatter->name(), 'Failed asserting that `->name()` returns expected value.');
+        $this->assertEquals('User', $formatter->singular_name(), 'Failed asserting that `->singular_name()` returns expected value.');
+    }
+
+    public function testFormatterComputedVariableGet()
+    {
+        $formatter = new Formatters\Example2(['name' => 'Users']);
+
+        // Computed variable cannot be retrieved with get()
+        try {
+            $this->assertEquals('users', $formatter->get('lower_plural'));
+        }
+        catch (\Exception $e) {
+            $this->assertInstanceOf(\ErrorException::class, $e, 'Failed asserting that `->get(\'lower_plural\')` does not exist.');
+        }
+
+        // Computed variable cannot be retrieved with __get()
+        try {
+            $this->assertEquals('users', $formatter->lower_plural);
+        }
+        catch (\Exception $e) {
+            $this->assertInstanceOf(\ErrorException::class, $e, 'Failed asserting that `->lower_plural` does not exist.');
+        }
+
+        // Will return computed variable
+        $this->assertEquals('users', $formatter->lower_plural(), 'Failed asserting that `->lower_plural()` returns expected value');
+    }
+
+    public function testFormatterVariableSet()
+    {
+        $formatter = new Formatters\Example2(['name' => 'Users']);
+
+        $this->assertFalse($formatter->has('package'), 'Failed asserting that variable \'package\' does not exist.');
+
+        $formatter->set('package', 'users-package');
+
+        $this->assertTrue($formatter->has('package'), 'Failed asserting that variable \'package\' exists.');
+
+        $variables = $formatter->all();
+
+        $this->assertEquals([
+            'name'          => 'Users',
+            'lower_plural'  => 'users',
+            'singular_name' => 'User',
+            'package'       => 'users-package',
+        ], $variables);
+    }
+
+    public function testFormatterVariableUnset()
+    {
+        $formatter = new Formatters\Example2(['name' => 'Users', 'package' => 'users-package']);
+
+        $this->assertTrue($formatter->has('package'), 'Failed asserting that variable \'package\' exists.');
+
+        $formatter->unset('package');
+
+        $this->assertFalse($formatter->has('package'), 'Failed asserting that variable \'package\' does not exist.');
+
+        $variables = $formatter->all();
+
+        $this->assertEquals([
+            'name'          => 'Users',
+            'lower_plural'  => 'users',
+            'singular_name' => 'User',
+        ], $variables);
+    }
+
+    public function testFormatterVariableMerge()
+    {
+        $formatter = new Formatters\Example1(['name' => 'User']);
+
+        $this->assertFalse($formatter->has('package'), 'Failed asserting that variable \'package\' does not exist.');
+
+        $formatter->merge([
+            'package'    => 'users-package',
+            'additional' => 'extra',
+        ]);
+
+        $this->assertTrue($formatter->has('package'), 'Failed asserting that variable \'package\' exists.');
+
+        $variables = $formatter->all();
+
+        $this->assertEquals([
+            'name'         => 'User',
+            'lower_plural' => 'users',
+            'package'      => 'users-package',
+            'additional'   => 'extra',
+        ], $variables);
+    }
 }

--- a/tests/Formatters/Example1.php
+++ b/tests/Formatters/Example1.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Formatters;
+
+use Stub\Formatter;
+
+class Example1 extends Formatter
+{
+    public function name()
+    {
+        return MockStr::singular($this->name);
+    }
+
+    public function lower_plural()
+    {
+        return MockStr::snake(MockStr::plural($this->name), '-');
+    }
+}

--- a/tests/Formatters/Example2.php
+++ b/tests/Formatters/Example2.php
@@ -6,12 +6,12 @@ use Stub\Formatter;
 
 class Example2 extends Formatter
 {
-    public function post_name()
+    public function singular_name()
     {
         return MockStr::singular($this->name);
     }
 
-    public function post_lower_plural()
+    public function lower_plural()
     {
         return MockStr::snake(MockStr::plural($this->name), '-');
     }

--- a/tests/Formatters/Example2.php
+++ b/tests/Formatters/Example2.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Formatters;
+
+use Stub\Formatter;
+
+class Example2 extends Formatter
+{
+    public function post_name()
+    {
+        return MockStr::singular($this->name);
+    }
+
+    public function post_lower_plural()
+    {
+        return MockStr::snake(MockStr::plural($this->name), '-');
+    }
+}

--- a/tests/Formatters/MockStr.php
+++ b/tests/Formatters/MockStr.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Formatters;
+
+class MockStr
+{
+    public static function studly(string $value)
+    {
+        $value = ucwords(str_replace(['-', '_'], ' ', $value));
+
+        return str_replace(' ', '', $value);
+    }
+
+    public static function snake(string $value, $delimiter = '_')
+    {
+        $value = preg_replace('/\s+/u', '', ucwords($value));
+        $value = strtolower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+
+        return $value;
+    }
+
+    public static function plural(string $value)
+    {
+        if (!preg_match('/(.*)s$/', $value)) {
+            return $value.'s';
+        }
+
+        return $value;
+    }
+
+    public static function singular(string $value)
+    {
+        if (preg_match('/(.*)s$/', $value, $matches)) {
+            return $matches[1];
+        }
+
+        return $value;
+    }
+
+    public static function title(string $value)
+    {
+        return ucwords($value);
+    }
+}

--- a/tests/Formatters/NovaTool.php
+++ b/tests/Formatters/NovaTool.php
@@ -35,7 +35,7 @@ class NovaTool extends Formatter
         return explode('/', $this->package)[0];
     }
 
-    protected function title()
+    public function title()
     {
         return MockStr::title(str_replace('-', ' ', $this->name()));
     }

--- a/tests/Formatters/NovaTool.php
+++ b/tests/Formatters/NovaTool.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Formatters;
+
+use InvalidArgumentException;
+
+use Stub\Formatter;
+
+class NovaTool extends Formatter
+{
+    protected function validate()
+    {
+        if (stripos($this->package, '/') === false) {
+            throw new InvalidArgumentException("The `package` variable expects a vendor and name in 'Composer' format. Here's an example: `vendor/name`.");
+        }
+    }
+
+    public function namespace()
+    {
+        return MockStr::studly($this->vendor()).'\\'.$this->class();
+    }
+
+    public function escapedNamespace()
+    {
+        return str_replace('\\', '\\\\', $this->namespace());
+    }
+
+    public function class()
+    {
+        return MockStr::studly($this->name());
+    }
+
+    public function vendor()
+    {
+        return explode('/', $this->package)[0];
+    }
+
+    protected function title()
+    {
+        return MockStr::title(str_replace('-', ' ', $this->name()));
+    }
+
+    public function component()
+    {
+        return $this->name();
+    }
+
+    public function name()
+    {
+        return explode('/', $this->package)[1];
+    }
+}

--- a/tests/Formatters/WithHelpers.php
+++ b/tests/Formatters/WithHelpers.php
@@ -11,13 +11,23 @@ class WithHelpers extends Formatter
         return MockStr::singular($this->name);
     }
 
+    public function test_helper()
+    {
+        return $this->helper();
+    }
+
+    public function test_helper_with_argument()
+    {
+        return $this->helper_with_argument('ARGUMENT');
+    }
+
     protected function helper()
     {
         return '__HELPER__';
     }
 
-    protected function helper_argument(string $argument)
+    protected function helper_with_argument(string $argument)
     {
-        return '__HELPER_ARGUMENT:'.$argument.'__';
+        return '__HELPER:'.$argument.'__';
     }
 }

--- a/tests/Formatters/WithHelpers.php
+++ b/tests/Formatters/WithHelpers.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Formatters;
+
+use Stub\Formatter;
+
+class WithHelpers extends Formatter
+{
+    public function name()
+    {
+        return MockStr::singular($this->name);
+    }
+
+    protected function helper()
+    {
+        return '__HELPER__';
+    }
+
+    protected function helper_argument(string $argument)
+    {
+        return '__HELPER_ARGUMENT:'.$argument.'__';
+    }
+}


### PR DESCRIPTION
I've had a go at reimplementing Formatters based on your solution.

I experimented with `get_class_methods()` and it does return `protected` if not `private` methods. I went with the reflection approach to only include public and zero-argument methods, to be totally sure.

I added validation back in, and some helper functions to work with the variables before they are passed to `render()`. You can also now pass a `Formatter` instance to `render()` as well as an array.

I haven't put anything in the README yet, in case things change as we discuss it, but basically this is the API:

### Basic formatter example

```php
use Stub\Formatter;
use Illuminate\Support\Str;

class MyFormatter extends Formatter
{
    public function plural()
    {
        return Str::plural($this->name);
    }
}
```

### Construct a formatter and retrieve variables with various methods

```php
$formatter = new MyFormatter(['name' => 'User']);

/*
MyFormatter Object
(
    [variables] => Array
        (
            [name] => User
        )
)
*/

```
#### Get all the variables and computed variables
```php
$variables = $formatter->all(); // Call `all()` method
$variables = $formatter(); // Invoke the class

/*
Array
(
    [name] => User
    [plural] => Users
)
*/
```
#### Get a single non-computed variable after the formatter is constructed
```php
$formatter->get('name'); // `get` method
$formatter->name; // Magic `__get`
$formatter->name(); // Magic `__call`, if `name()` method is not already defined
```
Note: `get('name')` and `name` will always return the original variable. If no public method `name()` is defined, this will also magically return the original variable, but if you add a `name()` method to modify the value of the variable, the modified variable will be returned.

#### Get a single computed variable after the formatter is constructed
```php
$formatter->plural();
```
Note: Computed variables can only be retrieved by their own methods, not `get()` or magic methods.

#### Add a single variable after the formatter is constructed
```php
$formatter->set('package', 'vendor/package');
```

#### Remove a single variable after the formatter is constructed
```php
$formatter->unset('package');
```

#### Merge an array of variables after the formatter is constructed
```php
$formatter->merge([
    'package' => 'vendor/package',
    'additional' => 'extra',
);
```

#### Replace all variables after the formatter is constructed
```php
$formatter->replace([
    'package' => 'vendor/package',
    'additional' => 'extra',
);
```

### Make a formatter and return original and computed variables at once

```php
$variables = MyFormatter::make(['name' => 'User']);

/*
Array
(
    [name] => User
    [plural] => Users
)
*/
```