### PR TITLE
pass Formatter to create()

### DIFF
--- a/src/Stub.php
+++ b/src/Stub.php
@@ -130,7 +130,7 @@ class Stub
      * @param string[]|\Stub\Formatter $variables
      * @return $this
      */
-    public function create(array $variables)
+    public function create($variables)
     {
         $variables = $this->orderByKeyLength($this->getVariableValues($variables));
 


### PR DESCRIPTION
remove unnecessary strict type that would prevent `Formatter` being passed in to `create()`